### PR TITLE
added trailing slash to phpmyadmin

### DIFF
--- a/info.js
+++ b/info.js
@@ -219,7 +219,7 @@ define(function(require, exports, module) {
          * Opens PHP My Admin, logged in, in a new window/tab
          */
         function openPHPMyAdmin() {
-            var pma = stats.host + '/phpmyadmin';
+            var pma = stats.host + '/phpmyadmin/';
             window.open(stats.user + ":" + stats.passwd + "@" + pma);
         }
 


### PR DESCRIPTION
This fixes the auto-login problem, but I'm still getting a problem where it has a new tab with the correct URL as such:

![screen shot 2016-07-15 at 10 29 51 am](https://cloud.githubusercontent.com/assets/7552511/16877632/220e351e-4a77-11e6-8a6f-49e6e02a1f4c.png)

But without going up to the toolbar and clicking enter, I don't get to this page:

<img width="1296" alt="screen shot 2016-07-15 at 10 30 44 am" src="https://cloud.githubusercontent.com/assets/7552511/16877647/34d73556-4a77-11e6-9d1d-953936e2f9f9.png">
