### PR TITLE
moved the version number to the left of the avatar menu in online IDE

### DIFF
--- a/info.js
+++ b/info.js
@@ -139,7 +139,7 @@ define(function(require, exports, module) {
             // place version button
             ui.insertByIndex(layout.findParent({
                 name: "preferences"
-            }), versionBtn, 860, plugin);
+            }), versionBtn, 500, plugin);
 
             // Add preference pane
             prefs.add({


### PR DESCRIPTION
The Avatar Menu is at location 600, so moving this to 500 will move it to the left of it in an online IDE. Tested this out by making a new button in the online and it works as expected.
