### PR TITLE
adds command to restart terminals

### DIFF
--- a/info.js
+++ b/info.js
@@ -230,11 +230,11 @@ define(function(require, exports, module) {
 
                     // determine warning based on number of terminals
                     var warning = (count === 2)
-                        ? "Doing so will kill any programs that are running in your terminal windows."
+                        ? "Doing so will kill any programs that are running in open terminal windows."
                         : "";
 
                     confirm("Update almost complete",
-                        "Reload CS50 IDE and restart terminal window in order to complete update?",
+                        "Reload CS50 IDE and restart terminal window" + (count == 2 ? "s" : "") + " to complete update?",
                         warning,
                         function(){
                             // find a terminal tab

--- a/info.js
+++ b/info.js
@@ -185,12 +185,12 @@ define(function(require, exports, module) {
                     fetching = true;
 
                     // write .info50
-                    fs.writeFile(path, content, function(err){
+                    fs.writeFile(path, content, function(err) {
                         if (err)
                             return console.error(err);
 
                         // make .info50 world-executable
-                        fs.chmod(path, 755, function(err){
+                        fs.chmod(path, 755, function(err) {
                             if (err)
                                 return console.error(err);
 
@@ -236,7 +236,7 @@ define(function(require, exports, module) {
                     confirm("Update almost complete",
                         "Reload CS50 IDE and restart terminal window" + (count == 2 ? "s" : "") + " to complete update?",
                         warning,
-                        function(){
+                        function() {
                             // find a terminal tab
                             var term = tabs.getTabs().find(function(tab) {
                                 return tab.editorType === "terminal";
@@ -263,7 +263,7 @@ define(function(require, exports, module) {
                                 }
                             });
                         },
-                        function(){}
+                        function() {}
                     );
                 }
             }, plugin);

--- a/info.js
+++ b/info.js
@@ -217,7 +217,7 @@ define(function(require, exports, module) {
 
             // add command to restart terminal sessions after update
             commands.addCommand({
-                name: "restterms",
+                name: "restart_terminals",
                 group: "Terminal",
                 hint: "Restarts all terminal sessions",
                 exec: function() {

--- a/info.js
+++ b/info.js
@@ -221,9 +221,21 @@ define(function(require, exports, module) {
                 group: "Terminal",
                 hint: "Restarts all terminal sessions",
                 exec: function() {
-                    confirm("Update complete!",
-                        "Restart all terminals and reload?",
-                        "WARNING: this will kill any programs running in your terminal(s)!",
+
+                    // find whether at least 2 terminals are open
+                    var count = 0;
+                    tabs.getTabs().some(function(tab) {
+                        return (tab.editorType === "terminal") && (++count === 2);
+                    });
+
+                    // determine warning based on number of terminals
+                    var warning = (count === 2)
+                        ? "Doing so will kill any programs that are running in your terminal windows."
+                        : "";
+
+                    confirm("Update almost complete",
+                        "Reload CS50 IDE and restart terminal window in order to complete update?",
+                        warning,
                         function(){
                             // find a terminal tab
                             var term = tabs.getTabs().find(function(tab) {

--- a/info.js
+++ b/info.js
@@ -228,14 +228,15 @@ define(function(require, exports, module) {
                         return (tab.editorType === "terminal") && (++count === 2);
                     });
 
-                    // determine warning based on number of terminals
-                    var warning = (count === 2)
-                        ? "Doing so will kill any programs that are running in open terminal windows."
-                        : "";
-
                     confirm("Update almost complete",
                         "Reload CS50 IDE and restart terminal window" + (count == 2 ? "s" : "") + " to complete update?",
-                        warning,
+
+                        // warn based on number of terminals
+                        (count === 2)
+                            ? "Doing so will kill any programs that are running in open terminal windows."
+                            : "",
+
+                        // OK
                         function() {
                             // find a terminal tab
                             var term = tabs.getTabs().find(function(tab) {
@@ -263,6 +264,8 @@ define(function(require, exports, module) {
                                 }
                             });
                         },
+
+                        // Cancel
                         function() {}
                     );
                 }


### PR DESCRIPTION
We should be able to use from `postinst` as in

```
c9 exec restterms
```

to automatically restart all terminal sessions and reload IDE tab after update.

![confirm](https://cloud.githubusercontent.com/assets/7230211/25069115/282ac870-2278-11e7-8586-dee063a9e25b.png)