### PR TITLE
registered listener using presentation api

### DIFF
--- a/info.js
+++ b/info.js
@@ -1,9 +1,9 @@
 define(function(require, exports, module) {
     main.consumes = [
         "api", "c9", "collab.workspace", "commands", "dialog.alert",
-        "dialog.confirm", "dialog.error", "dialog.notification", "fs", "http",
-        "layout", "menus", "Plugin", "preferences", "proc", "settings",
-        "tabManager", "terminal", "ui"
+        "dialog.confirm", "dialog.error", "dialog.notification", "fs",
+        "harvard.cs50.presentation", "http", "layout", "menus", "Plugin",
+        "preferences", "proc", "settings", "tabManager", "terminal", "ui"
     ];
     main.provides = ["harvard.cs50.info"];
     return main;
@@ -22,6 +22,7 @@ define(function(require, exports, module) {
         var menus = imports.menus;
         var notify = imports["dialog.notification"].show;
         var prefs = imports.preferences;
+        const presentation = imports["harvard.cs50.presentation"];
         var proc = imports.proc;
         var settings = imports.settings;
         var showError = imports["dialog.error"].show;
@@ -45,7 +46,6 @@ define(function(require, exports, module) {
         var timer = null;           // javascript interval ID
         var domain = null;          // current domain
         var BIN = "~/.cs50/bin/";
-        var presenting = false;
         var version = {};
 
         // info50 script
@@ -127,20 +127,7 @@ define(function(require, exports, module) {
                 name: "preferences"
             }), version.button, 500, plugin);
 
-            // cache whether presentation is on initially
-            presenting = settings.getBool("user/cs50/presentation/@presenting");
-
-            // set visibility of version number initially
-            toggleVersion(!presenting);
-
-            // handle toggling presentation
-            settings.on("user/cs50/presentation/@presenting", function(newVal) {
-                 // cache setting
-                presenting = newVal;
-
-                // toggle visibility of version number
-                toggleVersion(!presenting);
-            }, plugin);
+            presentation.addListener(presenting => toggleVersion(!presenting));
 
             // Add preference pane
             prefs.add({
@@ -457,10 +444,10 @@ define(function(require, exports, module) {
             // ensure button was initialized
             if (version.button) {
                 // forcibly hide while presentation is on or set to hide only
-                if (presenting || !show)
-                    version.button.hide();
-                else if (show)
+                if (show)
                     version.button.show();
+                else
+                    version.button.hide();
             }
         }
 
@@ -528,7 +515,6 @@ define(function(require, exports, module) {
             fetching = false;
             stats = null;
             domain = null;
-            presenting = false;
             version = {};
         });
 


### PR DESCRIPTION
The bug whereby version is not hidden if presentation is enabled after reload was caused by a race condition. It might be actually a bug in a core plugin because an event is fired as a result of setting default value of `user/cs50/presentation/@presenting` even when it already has a value. Regardless, I've made a change to cs50/harvard.cs50.presentation to have other plugins register event listeners for when presentation mode is toggled which I think is a cleaner approach than trying to read from the settings. I'll dig deeper into the potential bug in c9/core later.